### PR TITLE
Use date_create_from_format rather then strtotime

### DIFF
--- a/date_time_picker-v4.php
+++ b/date_time_picker-v4.php
@@ -342,10 +342,7 @@ class acf_field_date_time_picker extends acf_field
     function update_value( $value, $post_id, $field ) {
         $field = array_merge($this->defaults, $field);
         if ($value != '' && $field['save_as_timestamp'] == 'true') {
-            if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
-                $value = str_replace('/', '-', $value);
-            }
-            $value = strtotime( $value );
+            $value = date_create_from_format($this->js_to_php_dateformat($field['date_format']) . " " . $this->js_to_php_timeformat($field['time_format']), $value)->getTimeStamp();
         }
 
         return $value;


### PR DESCRIPTION
Fixes that values is not saved if you are using different datetime formats.
https://github.com/soderlind/acf-field-date-time-picker/issues/47
