### PR TITLE
live() replaced with on()

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -2,7 +2,7 @@
  *  Date and Time Picker
  */
 (function($){
-	$(document).live('acf/setup_fields', function(e, postbox){
+	$(document).on('acf/setup_fields', function(e, postbox){
 		$(postbox).find('input.ps_timepicker').each(function(){
 			var input = $(this)
 				, is_timeonly = (input.attr('data-date_format') == undefined)


### PR DESCRIPTION
WordPress 3.9 is using jQuery v1.11.0 http://api.jquery.com/live/
If you use it with ACF-Frontend-Edit, there might be no need for jquery-migrate, so using on() is much more compatible.
