### PR TITLE
Fix Undefined property: acf_field_date_time_picker::$domain

### DIFF
--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -17,8 +17,8 @@ class acf_field_date_time_picker extends acf_field
 		// vars
 		$this->name = 'date_time_picker';
 		$this->label = __('Date and Time Picker');
-		$this->category = __("jQuery", $this->domain); // Basic, Content, Choice, etc
 		$this->domain = 'acf-field-date-time-picker';
+		$this->category = __("jQuery", $this->domain); // Basic, Content, Choice, etc
 		$this->defaults = array(
 			 'label'             => __( 'Choose Time', $this->domain )
 			, 'time_format'       => 'h:mm tt'


### PR DESCRIPTION
Swapped over two lines so that acf_field_date_time_picker::$domain is defined before being used.
