### PR TITLE
Fix Backend Timestamp handling -- tested up WordPress 4.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### 2.0.17
+* Fix Backend Timestamp handling: `render_field` and Tested Up WordPress 4.0
+
 ### 2.0.16
 * Fix Undefined property: `acf_field_date_time_picker::$domain`
 

--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -153,11 +153,13 @@ class acf_field_date_time_picker extends acf_field
 	function render_field( $field ) {
 
 		if ( $field['show_date'] !== 'true' ) {
-			echo '<input type="text" value="' . $field['value'] . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-time_format="' . $field['time_format'] . '"  title="' . $field['label'] . '" />';
-		} else {
-			echo '<input type="text" value="' . $field['value'] . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-date_format="' . $field['date_format'] . '" data-time_format="' . $field['time_format'] . '" data-show_week_number="' . $field['show_week_number'] . '"  title="' . $field['label'] . '" />';
-		}
-	}
+            $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s",$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
+            echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-time_format="' . $field['time_format'] . '"  title="' . $field['label'] . '" />';
+        } else {
+            $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? $value = date_i18n(sprintf("%s %s", $this->js_to_php_dateformat($field['date_format']),$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
+            echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-date_format="' . $field['date_format'] . '" data-time_format="' . $field['time_format'] . '" data-show_week_number="' . $field['show_week_number'] . '"  title="' . $field['label'] . '" />';
+        }
+    }
 
 	function format_value($value, $post_id, $field)
 	{


### PR DESCRIPTION
Fix Issue #57 timestamp backend using Dynamic values as used to be
