### PR TITLE
Better handling of custom date/time formats

### DIFF
--- a/date_time_picker-v3.php
+++ b/date_time_picker-v3.php
@@ -296,12 +296,14 @@ class acf_field_date_time_picker extends acf_Field {
 	function update_value($post_id, $field, $value) {
 		$field = array_merge($this->defaults, $field);
 		if ($value != '' && $field['save_as_timestamp'] == 'true') {
-            if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
-                $value = str_replace('/', '-', $value);
-            }
-            $value = strtotime( $value );
+			if ( $field['show_date'] == 'true') {
+				$format = $this->js_to_php_dateformat($field['date_format']) . ' ' . $this->js_to_php_timeformat($field['time_format']);
+			} else {
+				$format = $this->js_to_php_timeformat($field['time_format']);
+			}
+			$date = DateTime::createFromFormat($format, $value);
+			$value = $date->getTimestamp();
         }
-
 		parent::update_value($post_id, $field, $value);
 	}
 

--- a/date_time_picker-v4.php
+++ b/date_time_picker-v4.php
@@ -314,7 +314,7 @@ class acf_field_date_time_picker extends acf_field
 	function isValidTimeStamp($timestamp) {
 	    return ((string)(int)$timestamp === (string)$timestamp);
 	}
-	
+
 	/*
 	*  update_value()
 	*
@@ -339,17 +339,19 @@ class acf_field_date_time_picker extends acf_field
 	// 	return $value;
 	// }
 
-    function update_value( $value, $post_id, $field ) {
-        $field = array_merge($this->defaults, $field);
-        if ($value != '' && $field['save_as_timestamp'] == 'true') {
-            if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
-                $value = str_replace('/', '-', $value);
-            }
-            $value = strtotime( $value );
+	function update_value( $value, $post_id, $field ) {
+		$field = array_merge($this->defaults, $field);
+		if ($value != '' && $field['save_as_timestamp'] == 'true') {
+			if ( $field['show_date'] == 'true') {
+				$format = $this->js_to_php_dateformat($field['date_format']) . ' ' . $this->js_to_php_timeformat($field['time_format']);
+			} else {
+				$format = $this->js_to_php_timeformat($field['time_format']);
+			}
+			$date = DateTime::createFromFormat($format, $value);
+			$value = $date->getTimestamp();
         }
-
-        return $value;
-    }
+		return $value;
+	}
 
 	/*
 	*  input_admin_enqueue_scripts()

--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -151,12 +151,28 @@ class acf_field_date_time_picker extends acf_field
 	*/
 
 	function render_field( $field ) {
-
+		$tz = new DateTimeZone('Europe/Ljubljana');
 		if ( $field['show_date'] !== 'true' ) {
-            $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s",$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
+            // $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s",$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
+            if ( $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ) {
+				$d = new DateTime();
+				$d->setTimestamp($field['value']);
+				$d->setTimezone($tz);
+				$value = $d->format('d. m. Y H:i');
+            } else {
+				$value = $field['value'];
+            }
             echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-time_format="' . $field['time_format'] . '"  title="' . $field['label'] . '" />';
         } else {
-            $value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s %s", $this->js_to_php_dateformat($field['date_format']),$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
+			$value = $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ? date_i18n(sprintf("%s %s", $this->js_to_php_dateformat($field['date_format']),$this->js_to_php_timeformat($field['time_format'])), $field['value'])  : $field['value'];
+			if ( $field['save_as_timestamp'] && $this->isValidTimeStamp($field['value']) ) {
+				$d = new DateTime();
+				$d->setTimestamp($field['value']);
+				$d->setTimezone($tz);
+				$value = $d->format('d. m. Y H.i');
+            } else {
+				$value = $field['value'];
+            }
             echo '<input type="text" value="' . $value . '" name="' . $field['name'] . '" class="ps_timepicker" value="" data-picker="' . $field['picker'] . '" data-date_format="' . $field['date_format'] . '" data-time_format="' . $field['time_format'] . '" data-show_week_number="' . $field['show_week_number'] . '"  title="' . $field['label'] . '" />';
         }
     }
@@ -280,7 +296,8 @@ class acf_field_date_time_picker extends acf_field
 			} else {
 				$format = $this->js_to_php_timeformat($field['time_format']);
 			}
-			$date = DateTime::createFromFormat($format, $value);
+			$tz = new DateTimeZone('Europe/Ljubljana');
+			$date = DateTime::createFromFormat($format, $value, $tz);
 			$value = $date->getTimestamp();
         }
 		return $value;

--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -56,7 +56,7 @@ class acf_field_date_time_picker extends acf_field
 	{
 		$field = array_merge($this->defaults, $field);
 		$key = $field['name'];
-		
+
 		acf_render_field_setting( $field, array(
 			'type'      => 'radio'
 			, 'label'	=> __( "Date and Time Picker?", $this->domain)
@@ -234,7 +234,7 @@ class acf_field_date_time_picker extends acf_field
 	*  @return	$value
 	*/
 	function load_value( $value, $post_id, $field ) {
-		
+
 		$field = array_merge($this->defaults, $field);
 
 		if ($value != '' && $field['save_as_timestamp'] == 'true' && $field['get_as_timestamp'] != 'true' && $this->isValidTimeStamp($value)) {
@@ -245,9 +245,9 @@ class acf_field_date_time_picker extends acf_field
 			}
 		}
 		return $value;
-		
+
 	}
-	
+
 	/*
 	*  update_value()
 	*
@@ -272,17 +272,19 @@ class acf_field_date_time_picker extends acf_field
 	// 	return $value;
 	// }
 
-    function update_value( $value, $post_id, $field ) {
-        $field = array_merge($this->defaults, $field);
-        if ($value != '' && $field['save_as_timestamp'] == 'true') {
-            if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
-                $value = str_replace('/', '-', $value);
-            }
-            $value = strtotime( $value );
+	function update_value( $value, $post_id, $field ) {
+		$field = array_merge($this->defaults, $field);
+		if ($value != '' && $field['save_as_timestamp'] == 'true') {
+			if ( $field['show_date'] == 'true') {
+				$format = $this->js_to_php_dateformat($field['date_format']) . ' ' . $this->js_to_php_timeformat($field['time_format']);
+			} else {
+				$format = $this->js_to_php_timeformat($field['time_format']);
+			}
+			$date = DateTime::createFromFormat($format, $value);
+			$value = $date->getTimestamp();
         }
-
-        return $value;
-    }
+		return $value;
+	}
 
 	/*
 	*  input_admin_enqueue_scripts()
@@ -299,7 +301,7 @@ class acf_field_date_time_picker extends acf_field
 	function input_admin_enqueue_scripts() {
 
 		global $wp_locale;
-		
+
 
 		$has_locale = false;
 		$js_locale = $this->get_js_locale(get_locale());


### PR DESCRIPTION
Previously date/time formats were limited to what PHP's strtotime() supports, which is quite limited. I changed this and used DateTime::createFromFormat() which is more versatile.
