### PR TITLE
convert localized month names before saving

### DIFF
--- a/date_time_picker-v3.php
+++ b/date_time_picker-v3.php
@@ -294,11 +294,33 @@ class acf_field_date_time_picker extends acf_Field {
 	*-------------------------------------------------------------------------------------*/
 
 	function update_value($post_id, $field, $value) {
+
+		global $wp_locale;
+
 		$field = array_merge($this->defaults, $field);
 		if ($value != '' && $field['save_as_timestamp'] == 'true') {
             if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
                 $value = str_replace('/', '-', $value);
             }
+
+			// convert localized month names into their respective english counterpart
+			$value = preg_replace(array_map(function ($month) {
+				return '/' . preg_quote($month) . '/';
+			}, $wp_locale->month), array(
+				'January',
+				'February',
+				'March',
+				'April',
+				'May',
+				'June',
+				'July',
+				'August',
+				'September',
+				'October',
+				'November',
+				'December'
+			), $value);
+
             $value = strtotime( $value );
         }
 

--- a/date_time_picker-v4.php
+++ b/date_time_picker-v4.php
@@ -340,11 +340,33 @@ class acf_field_date_time_picker extends acf_field
 	// }
 
     function update_value( $value, $post_id, $field ) {
+
+		global $wp_locale;
+
         $field = array_merge($this->defaults, $field);
         if ($value != '' && $field['save_as_timestamp'] == 'true') {
             if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
                 $value = str_replace('/', '-', $value);
             }
+
+			// convert localized month names into their respective english counterpart
+			$value = preg_replace(array_map(function ($month) {
+				return '/' . preg_quote($month) . '/';
+			}, $wp_locale->month), array(
+				'January',
+				'February',
+				'March',
+				'April',
+				'May',
+				'June',
+				'July',
+				'August',
+				'September',
+				'October',
+				'November',
+				'December'
+			), $value);
+
             $value = strtotime( $value );
         }
 

--- a/date_time_picker-v5.php
+++ b/date_time_picker-v5.php
@@ -273,11 +273,33 @@ class acf_field_date_time_picker extends acf_field
 	// }
 
     function update_value( $value, $post_id, $field ) {
+
+		global $wp_locale;
+
         $field = array_merge($this->defaults, $field);
         if ($value != '' && $field['save_as_timestamp'] == 'true') {
             if (preg_match('/^dd?\//',$field['date_format'] )) { //if start with dd/ or d/ (not supported by strtotime())
                 $value = str_replace('/', '-', $value);
             }
+
+			// convert localized month names into their respective english counterpart
+			$value = preg_replace(array_map(function ($month) {
+				return '/' . preg_quote($month) . '/';
+			}, $wp_locale->month), array(
+				'January',
+				'February',
+				'March',
+				'April',
+				'May',
+				'June',
+				'July',
+				'August',
+				'September',
+				'October',
+				'November',
+				'December'
+			), $value);
+
             $value = strtotime( $value );
         }
 


### PR DESCRIPTION
We experienced problems when saving german dates like „Oktober 7, 2015 00:00“. This pull request fixed the issue for us.
