### PR TITLE
Replace the jQuery function live() with on()

### DIFF
--- a/js/timepicker.js
+++ b/js/timepicker.js
@@ -89,7 +89,7 @@ acf = acf || {};
          *
          *  @return    n/a
          */
-        $(document).live('acf/setup_fields', function (e, postbox) {
+        $(document).on('acf/setup_fields', function (e, postbox) {
             $(postbox).find('input.ps_timepicker').each(function () {
                 var input = $(this),
                     is_timeonly = (input.attr('data-date_format') == undefined),


### PR DESCRIPTION
Since WordPress 5.6 has updated the default version of jQuery to 3.5.1 the function live() will no longer work which breaks this plugin. This code change switches to use 'on' instead.